### PR TITLE
Add SetSpanBytes to interface

### DIFF
--- a/bmt.go
+++ b/bmt.go
@@ -8,6 +8,10 @@ import (
 	"hash"
 )
 
+const (
+	SpanSize = 8
+)
+
 // Hash provides the necessary extension of the hash interface to add the length-prefix of the BMT hash.
 //
 // Any implementation should make it possible to generate a BMT hash using the hash.Hash interface only.
@@ -17,6 +21,9 @@ type Hash interface {
 
 	// SetSpan sets the length prefix of BMT hash.
 	SetSpan(int64) error
+
+	// SetSpanBytes sets the length prefix of BMT hash in byte form.
+	SetSpanBytes([]byte) error
 
 	// Capacity returns the maximum amount of bytes that will be processed by the implementation.
 	Capacity() int

--- a/legacy/bmt.go
+++ b/legacy/bmt.go
@@ -271,9 +271,19 @@ func (h *Hasher) WriteSection(idx int, data []byte) error {
 	return errors.New("This hasher only implements sequential writes. Please use Write() instead")
 }
 
-// SetSpan sets the span length value prefix for the current hash operation.
+// SetSpan sets the span length value prefix in numeric form for the current hash operation.
 func (h *Hasher) SetSpan(length int64) error {
 	span := LengthToSpan(length)
+	h.getTree().span = span
+	return nil
+}
+
+// SetSpanBytes sets the span length value prefix in bytes for the current hash operation.
+func (h *Hasher) SetSpanBytes(b []byte) error {
+	if len(b) != bmt.SpanSize {
+		return errors.New("invalid span size")
+	}
+	span := b
 	h.getTree().span = span
 	return nil
 }


### PR DESCRIPTION
Relieve client code of having to handle binary conversing between numerics and bytes when setting the span.